### PR TITLE
Fixed destroy method not reseting isInit value

### DIFF
--- a/src/simpleParallax.js
+++ b/src/simpleParallax.js
@@ -168,6 +168,9 @@ export default class SimpleParallax {
 
             // detach the resize event
             window.removeEventListener('resize', this.refresh);
+
+            // Reset isInit
+            isInit = false;
         }
     }
 }


### PR DESCRIPTION
Hi! 
I noticed that I have some issues when creating a new simpleParallax instance after destroying one that I just had created.

It seems that it is caused by the fact that isInit is still true, so proceedRequestAnimationFrame() is never called again.

I've fixed it by reseting isInit to false in the destroy method.

It's my first pull request ever I hope I did it properly 😄 