### PR TITLE
Add HTMLCollectionOf<Element> as data type of image parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare module 'simple-parallax-js' {
     }
 
     export default class SimpleParallax {
-        constructor(images: Element | Element[], settings?: IParallaxSettings);
+        constructor(images: Element | Element[] | HTMLCollectionOf<Element>, settings?: IParallaxSettings);
         public refresh: () => void;
         public destroy: () => void;
     }


### PR DESCRIPTION
Issue: 

I tried to use this library to my Angular app, and I tried to use the example that's provided on `README.md`,

```
import simpleParallax from 'simple-parallax-js';
var image = document.getElementsByClassName('parallax-img');
new simpleParallax(image);
```

And I got this error.

```
Argument of type 'HTMLCollectionOf<Element>' is not assignable to parameter of type 'Element | Element[]'.
  Type 'HTMLCollectionOf<Element>' is missing the following properties from type 'Element[]': pop, push, concat, join, and 25 more.
```
This is just `type` error, since the [getElementsByClassName](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName#:~:text=The%20getElementsByClassName%20method%20of%20Document,searched%2C%20including%20the%20root%20node.) return type is a `HTMLCollection`


Added `HTMLCollectionOf<Element>` as a data type of the image parameter.