### PR TITLE
move webpack & associated deps to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,10 @@
     "bugs": {
         "url": "https://github.com/geosigno/simpleParallax/issues"
     },
-    "dependencies": {
+    "devDependencies": {
         "html-webpack-plugin": "^4.3.0",
         "webpack": "^4.43.0",
-        "webpack-dev-server": "^3.11.0"
-    },
-    "devDependencies": {
+        "webpack-dev-server": "^3.11.0",
         "@babel/core": "^7.10.3",
         "@babel/preset-env": "^7.10.3",
         "babel-loader": "^8.1.0",


### PR DESCRIPTION
These packages :
```
"html-webpack-plugin": "^4.3.0",
"webpack": "^4.43.0",
"webpack-dev-server": "^3.11.0",
```
are not immediate dependencies of the project but are "dev dependencies" instead.
We should move them to the correct place because otherwize, the `npm install simple-parallax-js` or (`yarn add simple-parallax-js`) also installs these three dependencies (and their own deps and so on, more than 100 packages) on the project which uses simple-parallax-js, even if they are completely useless.